### PR TITLE
Fix an error

### DIFF
--- a/src/chat/chat.go
+++ b/src/chat/chat.go
@@ -84,7 +84,7 @@ func (u *User) readRequest() (*Request, error) {
 		return nil, err
 	}
 	if h.OpCode.IsControl() {
-		return nil, wsutil.ControlHandler(u.conn, ws.StateServerSide)(h, r)
+		return nil, wsutil.ControlFrameHandler(u.conn, ws.StateServerSide)(h, r)
 	}
 
 	req := &Request{}


### PR DESCRIPTION
./chat.go:87:36: too many arguments to conversion to
wsutil.ControlHandler: wsutil.ControlHandler(u.conn, ws.StateServerSide)